### PR TITLE
Update extract.csl2.file.R

### DIFF
--- a/R-libraries/casal2/R/extract.csl2.file.R
+++ b/R-libraries/casal2/R/extract.csl2.file.R
@@ -38,7 +38,7 @@
       }
     }
     i <- 1
-    while (i != length(file)) {
+    while (i <= length(file)) {
       if (tolower(substring(file[i], 1, 8)) == "!include") {
         temp <- string.to.vector.of.words(file[i])[2]
         temp <- gsub("\"", "", temp)


### PR DESCRIPTION
Bug fix: final include not read in unless there was a comment line after it

* **Please check that the PR fulfills these requirements**

- [ ] The commit message follows the Contributor Guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documents have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
if the final (non-blank) line of a csl2 file contains an !include, this file is not included, even with include=TRUE


* **What is the new behavior (if this is a feature change)?**
All lines checked for "!include"


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
